### PR TITLE
Use s2i/environment to fix run

### DIFF
--- a/.s2i/environment
+++ b/.s2i/environment
@@ -1,0 +1,1 @@
+ARTIFACT_COPY_ARGS=-p -r lib/ *-runner.jar


### PR DESCRIPTION
Running the app after a Source-2-Image build will get into an error like this:
```
Starting the Java application using /opt/jboss/container/java/run/run-java.sh ...
[0;31mERROR Neither $JAVA_MAIN_CLASS nor $JAVA_APP_JAR is set and 2 JARs found in /deployments (1 expected)[0m
INFO exec  java -javaagent:/usr/share/java/jolokia-jvm-agent/jolokia-jvm.jar=config=/opt/jboss/container/jolokia/etc/jolokia.properties -Xms94m -Xmx375m -XX:+UseParallelOldGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -XX:MaxMetaspaceSize=100m -XX:ParallelGCThreads=1 -Djava.util.concurrent.ForkJoinPool.common.parallelism=1 -XX:CICompilerCount=2 -XX:+ExitOnOutOfMemoryError -cp "." -jar
Error: -jar requires jar file specification
```

Adding the environment variable `ARTIFACT_COPY_ARGS=-p -r lib/ *-runner.jar` will fix it.